### PR TITLE
fixed typo refrence, but kept it backwards compatible for entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ You can add a new entry to the PO file:
 ```ruby
 new_entry = {
               translator_comment: 'comment',
-              refrence: 'refrence comment',
+              reference: 'reference comment',
               msgid: 'untranslated',
               msgstr: 'translated string'
             }
@@ -84,7 +84,7 @@ Adding plural string is the same:
 ```ruby
 new_entry = {
               translator_comment: 'comment',
-              refrence: 'refrence comment',
+              reference: 'reference comment',
               msgid_plural: 'untranslated',
               'msgstr[0]': 'translated string',
               'msgstr[1]': 'translated string'
@@ -100,7 +100,7 @@ Each entry can have following properties (for more information see [GNU PO file 
 
 ```
 translator_comment
-refrence
+reference
 extracted_comment
 flag
 previous_untraslated_string

--- a/lib/poparser/constants.rb
+++ b/lib/poparser/constants.rb
@@ -2,7 +2,7 @@ module PoParser
   COMMENTS_LABELS = {
     :translator_comment => '#',
     :extracted_comment => '#.',
-    :refrence => '#:',
+    :reference => '#:',
     :flag => '#,',
     :previous_untraslated_string => '#|',
     :cached => '#~'

--- a/lib/poparser/entry.rb
+++ b/lib/poparser/entry.rb
@@ -20,6 +20,9 @@ module PoParser
       self.class.send(:alias_method, :translate, :msgstr=)
       self.class.send(:alias_method, :obsolete, :cached)
       self.class.send(:alias_method, :obsolete=, :cached=)
+      # alias for backward compatibility of this typo
+      self.class.send(:alias_method, :refrence, :reference)
+      self.class.send(:alias_method, :refrence=, :reference)
     end
 
     # If entry doesn't have any msgid, it's probably a cached entry that is

--- a/lib/poparser/parser.rb
+++ b/lib/poparser/parser.rb
@@ -7,7 +7,7 @@ module PoParser
 
     # Comments
     rule(:comments) do
-      refrence |
+      reference |
       extracted_comment | flag |
       previous_untraslated_string |
       cached |
@@ -16,14 +16,14 @@ module PoParser
 
     rule(:translator_comment)         { spaced('#') >> comment_text_line.as(:translator_comment) }
     rule(:extracted_comment)          { spaced('#.') >> comment_text_line.as(:extracted_comment) }
-    rule(:refrence)                   { spaced('#:') >> comment_text_line.as(:refrence) }
+    rule(:reference)                   { spaced('#:') >> comment_text_line.as(:reference) }
     rule(:flag)                       { spaced('#,') >> comment_text_line.as(:flag) }
     rule(:previous_untraslated_string){ spaced('#|') >> comment_text_line.as(:previous_untraslated_string) }
     rule(:cached)                     { spaced('#~') >> comment_text_line.as(:cached) }
 
     # Entries
     rule(:entries) do
-      msgid.as(:msgid) | 
+      msgid.as(:msgid) |
       msgid_plural.as(:msgid_plural) |
       msgstr.as(:msgstr) |
       msgstr_plural.as(:msgstr_plural) |
@@ -65,4 +65,3 @@ module PoParser
     end
   end
 end
-

--- a/lib/poparser/po.rb
+++ b/lib/poparser/po.rb
@@ -15,7 +15,7 @@ module PoParser
     # @example
     #   entry = {
     #             translator_comment: 'comment',
-    #             refrence: 'refrense comment',
+    #             reference: 'reference comment',
     #             flag: 'fuzzy',
     #             msgid: 'translatable string',
     #             msgstr: 'translation'

--- a/spec/poparser/entry_spec.rb
+++ b/spec/poparser/entry_spec.rb
@@ -8,7 +8,7 @@ describe PoParser::Entry do
   end
 
   let(:labels) do
-    [:refrence, :extracted_comment, :flag, :previous_untraslated_string,
+    [:reference, :refrence, :extracted_comment, :flag, :previous_untraslated_string,
       :translator_comment, :msgid, :msgid_plural, :msgstr, :msgctxt]
   end
 

--- a/spec/poparser/parser_spec.rb
+++ b/spec/poparser/parser_spec.rb
@@ -7,7 +7,7 @@ describe PoParser::Parser do
   context(:comments) do
 
     let(:tc)  { po.translator_comment }
-    let(:rc)  { po.refrence }
+    let(:rc)  { po.reference }
     let(:ec)  { po.extracted_comment }
     let(:fc)  { po.flag }
     let(:pusc){ po.previous_untraslated_string }

--- a/spec/poparser/po_spec.rb
+++ b/spec/poparser/po_spec.rb
@@ -5,7 +5,7 @@ describe PoParser::Po do
   let (:entry) do
     {
       translator_comment: 'comment',
-      refrence: 'refrence comment',
+      reference: 'reference comment',
       msgid: 'untranslated',
       msgstr: 'translated string'
     }

--- a/spec/poparser/tokenizer_spec.rb
+++ b/spec/poparser/tokenizer_spec.rb
@@ -5,7 +5,7 @@ describe PoParser::Tokenizer do
   let(:token)  { PoParser::Tokenizer.new }
   let(:po_file){ Pathname.new('spec/poparser/fixtures/tokenizer.po').realpath }
   let(:po_file_empty_line){ Pathname.new('spec/poparser/fixtures/tokenizer_empty_line.po').realpath }
-  let(:result) { [{:refrence=>"templates:105", :msgid=>"Afrikaans", :msgstr=>"آفریقایی"}, {:flag=>"fuzzy", :msgid=>"Afrikaans", :msgstr=>"آفریقایی" }] }
+  let(:result) { [{:reference=>"templates:105", :msgid=>"Afrikaans", :msgstr=>"آفریقایی"}, {:flag=>"fuzzy", :msgid=>"Afrikaans", :msgstr=>"آفریقایی" }] }
 
   it 'should be able to extracts entries' do
     expect(


### PR DESCRIPTION
fixed your typo of reference, but added alias methods so code using "refrence" on entries still works.

a version bump even without the "merge bug" would be appreciated ;)