### PR TITLE
to_s should return a string

### DIFF
--- a/lib/poparser/comment.rb
+++ b/lib/poparser/comment.rb
@@ -22,7 +22,7 @@ module PoParser
     end
 
     def to_str
-      @value
+      @value.is_a?(Array) ? @value.join : @value
     end
 
     def inspect

--- a/lib/poparser/comment.rb
+++ b/lib/poparser/comment.rb
@@ -1,32 +1,32 @@
 module PoParser
   class Comment
-    attr_accessor :type, :str
+    attr_accessor :type, :value
 
-    def initialize(type, str)
+    def initialize(type, value)
       @type = type
-      @str  = str
+      @value  = value
     end
 
     def to_s(with_label = false)
-      return @str unless with_label
-      if @str.is_a? Array
+      return to_str unless with_label
+      if @value.is_a? Array
         string = []
-        @str.each do |str|
+        @value.each do |str|
           string << "#{COMMENTS_LABELS[@type]} #{str}\n".gsub(/[^\S\n]+$/, '')
         end
         return string.join
       else
         # removes the space but not newline at the end
-        "#{COMMENTS_LABELS[@type]} #{@str}\n".gsub(/[^\S\n]+$/, '')
+        "#{COMMENTS_LABELS[@type]} #{@value}\n".gsub(/[^\S\n]+$/, '')
       end
     end
 
     def to_str
-      @str
+      @value
     end
 
     def inspect
-      @str
+      @value
     end
   end
 end

--- a/lib/poparser/entry.rb
+++ b/lib/poparser/entry.rb
@@ -146,7 +146,7 @@ module PoParser
             if instance_variable_get("@#{type}".to_sym).is_a? object
               klass      = instance_variable_get "@#{type}".to_sym
               klass.type = type
-              klass.str  = val
+              klass.value  = val
             else
               instance_variable_set "@#{type}".to_sym, object.new(type, val)
             end

--- a/lib/poparser/header.rb
+++ b/lib/poparser/header.rb
@@ -46,7 +46,7 @@ module PoParser
 
   private
     def convert_msgstr_to_hash(msgstr)
-      options_array = msgstr.to_s.map do |options|
+      options_array = msgstr.value.map do |options|
         options.split(':', 2).each do |k|
           k.strip!
           k.chomp!
@@ -70,4 +70,3 @@ module PoParser
     end
   end
 end
-

--- a/lib/poparser/header.rb
+++ b/lib/poparser/header.rb
@@ -7,7 +7,7 @@ module PoParser
 
     def initialize(entry)
       @entry            = entry
-      @comments         = entry.translator_comment.to_s
+      @comments         = entry.translator_comment.value
       @original_configs = convert_msgstr_to_hash(entry.msgstr)
 
       HEADER_LABELS.each do |k, v|

--- a/lib/poparser/message.rb
+++ b/lib/poparser/message.rb
@@ -1,46 +1,45 @@
 module PoParser
   class Message
-    attr_accessor :type
-    attr_writer :str
+    attr_accessor :type, :value
 
-    def initialize(type, str)
+    def initialize(type, value)
       @type = type
-      @str  = str
+      @value  = value
 
       remove_empty_line
     end
 
     def str
-      @str.is_a?(Array) ? @str.join : @str
+      @value.is_a?(Array) ? @value.join : @value
     end
 
     def to_s(with_label = false)
-      return @str unless with_label
-      if @str.is_a? Array
+      return to_str unless with_label
+      if @value.is_a? Array
         remove_empty_line
         # multiline messages should be started with an empty line
         lines = ["#{label} \"\"\n"]
-        @str.each do |str|
+        @value.each do |str|
           lines << "\"#{str}\"\n"
         end
         return lines.join
       else
-        "#{label} \"#{@str}\"\n"
+        "#{label} \"#{@value}\"\n"
       end
     end
 
     def to_str
-      @str.is_a?(Array) ? @str.join : @str
+      @value.is_a?(Array) ? @value.join : @value
     end
 
     def inspect
-      @str
+      @value
     end
 
   private
     def remove_empty_line
-      if @str.is_a? Array
-        @str.shift if @str.first == ''
+      if @value.is_a? Array
+        @value.shift if @value.first == ''
       end
     end
 


### PR DESCRIPTION
It kind of consufes me that `to_s` doesn't mean "to_string" if the message/comment content is actually an array.

`to_str` does what I expect though and concatenates the array to a string.

Did you actually mean it to be that way or was is it just some kind of laziness? I really didn't expect it to be like that.

I prepared a pull_request. It replaces the `@str` variable of message and content to the less confusing `@value` and will call `to_str` in `to_s` if called without label to properly handle arrays.

This is a non-backward compatible change and will break code that expects multiline msgstr/msgid are given as a array on `to_s`. The header uses `.value.map` instead of `.to_s.map` now.