### PR TITLE
Fix and enhance previous comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,9 @@ translator_comment
 reference
 extracted_comment
 flag
-previous_untraslated_string
+previous_msgctxt
+previous_msgid
+previous_msgid_plural
 cached # obsolete entries
 msgid
 msgid_plural

--- a/README.md
+++ b/README.md
@@ -142,6 +142,16 @@ entry.msgstr.to_s
 #=> "This entry is translated"
 ```
 
+But be careful with plural messages, there msgstr is an array
+```ruby
+if entry.plural?
+  entry.msgstr.each do |msgstr|
+    msgstr.to_s
+    #=> This is one of the plural translations
+  end  
+end  
+```
+
 You can mark an entry as fuzzy:
 
 ```ruby

--- a/lib/poparser/comment.rb
+++ b/lib/poparser/comment.rb
@@ -10,14 +10,25 @@ module PoParser
     def to_s(with_label = false)
       return to_str unless with_label
       if @value.is_a? Array
-        string = []
-        @value.each do |str|
-          string << "#{COMMENTS_LABELS[@type]} #{str}\n".gsub(/[^\S\n]+$/, '')
+        if @type.to_s =~ /^previous_/ # these behave more like messages
+          string = ["#{COMMENTS_LABELS[@type]} \"\"\n"]
+          @value.each do |str|
+            string << "#| \"#{str}\"\n".gsub(/[\p{Blank}]+$/, '')
+          end
+        else
+          string = []
+          @value.each do |str|
+            string << "#{COMMENTS_LABELS[@type]} #{str}\n".gsub(/[\p{Blank}]+$/, '')
+          end
         end
         return string.join
       else
-        # removes the space but not newline at the end
-        "#{COMMENTS_LABELS[@type]} #{@value}\n".gsub(/[^\S\n]+$/, '')
+        if @type.to_s =~ /^previous_/ # these behave more like messages
+          "#{COMMENTS_LABELS[@type]} \"#{@value}\"\n".gsub(/[\p{Blank}]+$/, '')
+        else
+          # removes the space but not newline at the end
+          "#{COMMENTS_LABELS[@type]} #{@value}\n".gsub(/[\p{Blank}]+$/, '')
+        end
       end
     end
 

--- a/lib/poparser/comment.rb
+++ b/lib/poparser/comment.rb
@@ -11,6 +11,7 @@ module PoParser
       return to_str unless with_label
       if @value.is_a? Array
         if @type.to_s =~ /^previous_/ # these behave more like messages
+          remove_empty_line
           string = ["#{COMMENTS_LABELS[@type]} \"\"\n"]
           @value.each do |str|
             string << "#| \"#{str}\"\n".gsub(/[\p{Blank}]+$/, '')
@@ -38,6 +39,13 @@ module PoParser
 
     def inspect
       @value
+    end
+
+  private
+    def remove_empty_line
+      if @value.is_a? Array
+        @value.shift if @value.first == ''
+      end
     end
   end
 end

--- a/lib/poparser/constants.rb
+++ b/lib/poparser/constants.rb
@@ -4,9 +4,9 @@ module PoParser
     :extracted_comment => '#.',
     :reference => '#:',
     :flag => '#,',
+    :previous_msgctxt => '#| msgctxt',
     :previous_msgid => '#| msgid',
     :previous_msgid_plural => '#| msgid_plural',
-    :previous_msgctxt => '#| msgctxt',
     :cached => '#~'
   }
 

--- a/lib/poparser/constants.rb
+++ b/lib/poparser/constants.rb
@@ -4,7 +4,9 @@ module PoParser
     :extracted_comment => '#.',
     :reference => '#:',
     :flag => '#,',
-    :previous_untraslated_string => '#|',
+    :previous_msgid => '#| msgid',
+    :previous_msgid_plural => '#| msgid_plural',
+    :previous_msgctxt => '#| msgctxt',
     :cached => '#~'
   }
 

--- a/lib/poparser/entry.rb
+++ b/lib/poparser/entry.rb
@@ -25,19 +25,6 @@ module PoParser
       self.class.send(:alias_method, :refrence=, :reference)
     end
 
-    def previous_untraslated_string
-      if @previous_msgctxt | @previous_msgid | @previous_msgid_plural
-        previous_untraslated_string = ""
-        previous_untraslated_string += @previous_msgctxt.to_s(true) if @previous_msgctxt
-        previous_untraslated_string += @previous_msgid.to_s(true) if @previous_msgid
-        previous_untraslated_string += @previous_msgid_plural.to_s(true) if @previous_msgid_plural
-        previous_untraslated_string
-      else
-        nil
-      end
-    end
-
-
     # If entry doesn't have any msgid, it's probably a cached entry that is
     # kept by the program for later use. These entries will usually start with: #~
     #

--- a/lib/poparser/entry.rb
+++ b/lib/poparser/entry.rb
@@ -25,6 +25,19 @@ module PoParser
       self.class.send(:alias_method, :refrence=, :reference)
     end
 
+    def previous_untraslated_string
+      if @previous_msgctxt | @previous_msgid | @previous_msgid_plural
+        previous_untraslated_string = ""
+        previous_untraslated_string += @previous_msgctxt.to_s(true) if @previous_msgctxt
+        previous_untraslated_string += @previous_msgid.to_s(true) if @previous_msgid
+        previous_untraslated_string += @previous_msgid_plural.to_s(true) if @previous_msgid_plural
+        previous_untraslated_string
+      else
+        nil
+      end
+    end
+
+
     # If entry doesn't have any msgid, it's probably a cached entry that is
     # kept by the program for later use. These entries will usually start with: #~
     #

--- a/lib/poparser/parser.rb
+++ b/lib/poparser/parser.rb
@@ -7,19 +7,27 @@ module PoParser
 
     # Comments
     rule(:comments) do
-      reference |
-      extracted_comment | flag |
-      previous_untraslated_string |
-      cached |
-      translator_comment
+      reference.as(:reference) |
+      extracted_comment.as(:extracted_comment) |
+      flag.as(:flag) |
+      previous_msgctxt.as(:previous_msgctxt) |
+      previous_msgid.as(:previous_msgid) |
+      previous_msgid_plural.as(:previous_msgid_plural) |
+      cached.as(:cached) |
+      translator_comment.as(:translator_comment)
     end
 
-    rule(:translator_comment)         { spaced('#') >> comment_text_line.as(:translator_comment) }
-    rule(:extracted_comment)          { spaced('#.') >> comment_text_line.as(:extracted_comment) }
-    rule(:reference)                   { spaced('#:') >> comment_text_line.as(:reference) }
-    rule(:flag)                       { spaced('#,') >> comment_text_line.as(:flag) }
-    rule(:previous_untraslated_string){ spaced('#|') >> comment_text_line.as(:previous_untraslated_string) }
-    rule(:cached)                     { spaced('#~') >> comment_text_line.as(:cached) }
+    rule(:translator_comment)       { spaced('#') >> comment_text_line }
+    rule(:extracted_comment)        { spaced('#.') >> comment_text_line }
+    rule(:reference)                { spaced('#:') >> comment_text_line }
+    rule(:flag)                     { spaced('#,') >> comment_text_line }
+    rule(:previous_msgctxt)         { spaced('#| msgctxt') >> msg_text_line >> previous_multiline.repeat }
+    rule(:previous_msgid)           { spaced('#| msgid') >> msg_text_line >> previous_multiline.repeat }
+    rule(:previous_msgid_plural)    { spaced('#| msgid_plural') >> msg_text_line >> previous_multiline.repeat }
+    rule(:cached)                   { spaced('#~') >> comment_text_line }
+
+    rule(:previous_multiline)       { previous_multiline_start.present? >> spaced('#|') >> msg_text_line.repeat.maybe }
+    rule(:previous_multiline_start) { spaced('#|') >> str('"') }
 
     # Entries
     rule(:entries) do

--- a/spec/poparser/entry_spec.rb
+++ b/spec/poparser/entry_spec.rb
@@ -8,7 +8,7 @@ describe PoParser::Entry do
   end
 
   let(:labels) do
-    PoParser::LABELS + [:refrence, :previous_untraslated_string]  # backward typos
+    PoParser::LABELS + [:refrence]  # backward typos
   end
 
   it 'should respond to labels' do
@@ -32,10 +32,6 @@ describe PoParser::Entry do
   it 'should translate the entry' do
     @entry.translate ('this entry is translated')
     expect(@entry.msgstr.to_s).to eq 'this entry is translated'
-  end
-
-  it 'should respond to previous_untraslated_string' do
-
   end
 
   it 'checks if the entry is translated' do

--- a/spec/poparser/entry_spec.rb
+++ b/spec/poparser/entry_spec.rb
@@ -8,8 +8,7 @@ describe PoParser::Entry do
   end
 
   let(:labels) do
-    [:reference, :refrence, :extracted_comment, :flag, :previous_untraslated_string,
-      :translator_comment, :msgid, :msgid_plural, :msgstr, :msgctxt]
+    PoParser::LABELS + [:refrence, :previous_untraslated_string]  # backward typos
   end
 
   it 'should respond to labels' do
@@ -33,6 +32,10 @@ describe PoParser::Entry do
   it 'should translate the entry' do
     @entry.translate ('this entry is translated')
     expect(@entry.msgstr.to_s).to eq 'this entry is translated'
+  end
+
+  it 'should respond to previous_untraslated_string' do
+
   end
 
   it 'checks if the entry is translated' do
@@ -87,6 +90,24 @@ describe PoParser::Entry do
       @entry.msgstr = ['first line', 'second line']
       result = "#, fuzzy\nmsgid \"\"\n\"first line\"\n\"second line\"\nmsgstr \"\"\n\"first line\"\n\"second line\"\n"
       expect(@entry.to_s).to eq(result)
+    end
+  end
+
+  context 'Previous' do
+    it 'should be able to show content of previous_msgid' do
+      @entry.previous_msgid = 'Hello'
+      result = "Hello"
+      result_with_label = "#| msgid \"Hello\"\n"
+      expect(@entry.previous_msgid.to_s).to eq result
+      expect(@entry.previous_msgid.to_s(true)).to eq result_with_label
+    end
+
+    it 'convert multiline entries to string' do
+      @entry.previous_msgid = ['first line', 'second line']
+      result = "first linesecond line"
+      result_with_label = "#| msgid \"\"\n#| \"first line\"\n#| \"second line\"\n"
+      expect(@entry.previous_msgid.to_s).to eq result
+      expect(@entry.previous_msgid.to_s(true)).to eq result_with_label
     end
   end
 

--- a/spec/poparser/parser_spec.rb
+++ b/spec/poparser/parser_spec.rb
@@ -9,7 +9,9 @@ describe PoParser::Parser do
     let(:rc)  { po.reference }
     let(:ec)  { po.extracted_comment }
     let(:fc)  { po.flag }
-    let(:pusc){ po.previous_untraslated_string }
+    let(:pmsgctxtc){ po.previous_msgctxt }
+    let(:pmsgidc){ po.previous_msgid }
+    let(:pmsgid_pluralc){ po.previous_msgid_plural }
 
     it 'parses the translator comment' do
       expect(tc).to parse("# Persian translation for damned-lies 123123\n")
@@ -29,11 +31,37 @@ describe PoParser::Parser do
       expect(fc).to parse("#, python-format\n")
     end
 
-    it 'parses previous_untraslated_string' do
-      expect(pusc).to parse("#| msgid \"\"\n")
-      expect(pusc).to parse("#| \"Hello,\\n\"\n")
-      expect(pusc).to parse("#| \"The new state of %(module)s - %(branch)s - %(domain)s (%(language)s) is \"\n")
+    it 'parses previous msgctxt' do
+      # single line
+      expect(pmsgctxtc).to parse("#| msgctxt \"Context\"\n")
+      # multiline
+      pmsgctxt = "#| msgctxt \"\"\n"
+      pmsgctxt += "#| \"Multiline context\\n\"\n"
+      pmsgctxt += "#| \"cause its fun\"\n"
+      expect(pmsgctxtc).to parse(pmsgctxt)
     end
+
+    it 'parses previous msgid' do
+      # single line
+      expect(pmsgidc).to parse("#| msgid \"Hi there\"\n")
+      # multiline
+      pmsgid = "#| msgid \"\"\n"
+      pmsgid += "#| \"Hello,\\n\"\n"
+      pmsgid += "#| \"The new state of %(module)s - %(branch)s - %(domain)s (%(language)s) is \"\n"
+      expect(pmsgidc).to parse(pmsgid)
+    end
+
+    it 'parses previous msgid_plural' do
+      # single line
+      expect(pmsgid_pluralc).to parse("#| msgid_plural \"Hi there\"\n")
+      # multiline
+      pmsgid_plural = "#| msgid_plural \"\"\n"
+      pmsgid_plural += "#| \"Hello,\\n\"\n"
+      pmsgid_plural += "#| \"The new state of %(module)s - %(branch)s - %(domain)s (%(language)s) is \"\n"
+      expect(pmsgid_pluralc).to parse(pmsgid_plural)
+    end
+
+
   end
 
   context 'Entries' do


### PR DESCRIPTION
fixes and enhances previous comment handling to recognize msgid, msgid_plural and msgctxt separetely. Also handles multiline entries in there like done by messages.

This is required as it can actually occure on msgmerge. Here is an example entry generated by msgmerge:

```
# excelrow: 1337
msgctxt "Multiline"
msgid ""
"Gespeicherte Nachricht\n"
"nicht gefunden"
msgid_plural ""
"Gespeicherte Nachrichten\n"
"nicht gefunden"
msgstr[0] ""
"Saved message\n"
"not found"
msgstr[1] ""
"Saved messages\n"
"not found"

# excelrow: 1337
#, fuzzy
#| msgctxt "Multiline"
#| msgid ""
#| "Gespeicherte Nachricht\n"
#| "nicht gefunden"
#| msgid_plural ""
#| "Gespeicherte Nachrichten\n"
#| "nicht gefunden"
msgctxt "Multiline2"
msgid ""
"Gespeicherte Nachricht\n"
"nicht gefunden"
msgid_plural ""
"Gespeicherte Nachrichten\n"
"nicht gefunden"
msgstr[0] ""
"Saved message\n"
"not found"
msgstr[1] ""
"Saved messages\n"
"not found"
```

Again this pull requests 'as is' is not backward compatible. Though you could enable a "kind of" backward compatibility for at least getting "previous_untraslated_string" (with typo) by looking at the "removed backward comp..." commit. As we moved to version 2.0 14 days ago, i would argue to just go to 2.0.2 and don't enable it.

Providing full backward compatibility would require to parse input on "previous_untraslated_string=". I don't think it's worth the trouble and can't think of a use case for this anyway.