### PR TITLE
be more strict about the simple_po_parser version

### DIFF
--- a/poparser.gemspec
+++ b/poparser.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   # Runtime deps
-  spec.add_runtime_dependency "simple_po_parser", "~> 1.1"
+  spec.add_runtime_dependency "simple_po_parser", "~> 1.1.2"
 
   # Development deps
   spec.add_development_dependency "bundler", ">= 0"


### PR DESCRIPTION
in the next release, we could be more strict about the simple_po_parser version to only accept ~> 1.1.2 (>=1.1.2 and <1.2), especially as 1.1.1 is not thread-safe.