### PR TITLE
parse content of obsolete entries

### DIFF
--- a/lib/poparser/comment.rb
+++ b/lib/poparser/comment.rb
@@ -5,13 +5,16 @@ module PoParser
     def initialize(type, value)
       @type = type
       @value  = value
+
+      if @type.to_s =~ /^previous_/ # these behave more like messages
+        remove_empty_line
+      end
     end
 
     def to_s(with_label = false)
       return to_str unless with_label
       if @value.is_a? Array
         if @type.to_s =~ /^previous_/ # these behave more like messages
-          remove_empty_line
           string = ["#{COMMENTS_LABELS[@type]} \"\"\n"]
           @value.each do |str|
             string << "#| \"#{str}\"\n".gsub(/[\p{Blank}]+$/, '')

--- a/lib/poparser/entry.rb
+++ b/lib/poparser/entry.rb
@@ -23,6 +23,13 @@ module PoParser
       # alias for backward compatibility of this typo
       self.class.send(:alias_method, :refrence, :reference)
       self.class.send(:alias_method, :refrence=, :reference=)
+      if self.obsolete?
+        obsolete_content = SimplePoParser.parse_message(obsolete.value.join("\n").gsub(/^\|/, "#|"))
+        obsolete_content.each do |name, value|
+          raise(ArgumentError, "Unknown label #{name}") if !valid_label? name
+          set_instance_variable(name, value)
+        end
+      end
     end
 
     # If entry doesn't have any msgid, it's probably a obsolete entry that is

--- a/lib/poparser/po.rb
+++ b/lib/poparser/po.rb
@@ -86,7 +86,7 @@ module PoParser
         entry.obsolete?
       end
     end
-    alias_method :obsolete, :obsolete
+    alias_method :cached, :obsolete
 
     # Count of all entries without counting obsolete entries
     #

--- a/poparser.gemspec
+++ b/poparser.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   # Runtime deps
-  spec.add_runtime_dependency "simple_po_parser", "~> 1.1"
+  spec.add_runtime_dependency "simple_po_parser", "~> 1.1.2"
 
   # Development deps
   spec.add_development_dependency "bundler", ">= 0"

--- a/spec/poparser/entry_spec.rb
+++ b/spec/poparser/entry_spec.rb
@@ -110,7 +110,7 @@ describe PoParser::Entry do
   context 'obsolete' do
     before do
       @entry = PoParser::Entry.new
-      @entry.obsolete = '#~ msgid "a obsolete entry"'
+      @entry.obsolete = ['#~ msgid "a obsolete entry"', '#~ msgstr ""']
       @entry.flag = 'Fuzzy'
     end
 
@@ -130,5 +130,21 @@ describe PoParser::Entry do
     it 'shouldn\'t mark it as fuzzy' do
       expect(@entry.fuzzy?).to be_falsy
     end
+
+    it 'should further parse the obsolete content' do
+      path = Pathname.new('spec/poparser/fixtures/complex_obsolete.po').realpath
+      @po = PoParser::Tokenizer.new.extract_entries(path)
+      obsolete_entry = @po.obsolete.first
+      expect(obsolete_entry.obsolete?).to be_truthy
+      expect(obsolete_entry.msgctxt.value).to eq('Context')
+      expect(obsolete_entry.msgid.value).to eq('msgid')
+      expect(obsolete_entry.msgid_plural.value).to eq(['multiline msgid_plural\n', ''])
+      expect(obsolete_entry.previous_msgctxt.value).to eq('previous context')
+      expect(obsolete_entry.previous_msgid.value).to eq(
+        ['multiline\n', 'previous messageid']
+      )
+      expect(obsolete_entry.previous_msgid_plural.value).to eq('previous msgid_plural')
+    end
+
   end
 end

--- a/spec/poparser/fixtures/complex_obsolete.po
+++ b/spec/poparser/fixtures/complex_obsolete.po
@@ -1,0 +1,21 @@
+# translator-comment
+#
+#. extract
+#: reference1
+#: reference2
+#, flag
+#~| msgctxt "previous context"
+#~| msgid ""
+#~| "multiline\n"
+#~| "previous messageid"
+#~| msgid_plural "previous msgid_plural"
+#~ msgctxt "Context"
+#~ msgid "msgid"
+#~ msgid_plural ""
+#~ "multiline msgid_plural\n"
+#~ ""
+#~ msgstr[0] "msgstr 0"
+#~ msgstr[1] ""
+#~ "msgstr 1 multiline 1\n"
+#~ "msgstr 1 line 2\n"
+#~ msgstr[2] "msgstr 2"

--- a/spec/poparser/po_spec.rb
+++ b/spec/poparser/po_spec.rb
@@ -41,7 +41,7 @@ describe PoParser::Po do
 
   it 'returns all obsolete strings' do
     entry2, entry3 = entry.dup, entry.dup
-    [entry2, entry3].each { |en| en[:obsolete] = 'test' }
+    [entry2, entry3].each { |en| en[:obsolete] = ['msgid "test"', 'msgstr "test"'] }
     @po << [entry, entry2, entry3]
     expect(@po.obsolete.size).to eq 2
   end
@@ -60,7 +60,7 @@ describe PoParser::Po do
 
   it 'shouldn\'t count obsolete entries' do
     @po << entry
-    obsolete = { obsolete: 'sth', flag: 'Fuzzy' }
+    obsolete = { obsolete: ['msgid "sth"', 'msgstr "sth"'], flag: 'Fuzzy' }
     @po << obsolete
     expect(@po.size).to eq(1)
   end
@@ -124,4 +124,5 @@ describe PoParser::Po do
         }.to raise_error(RuntimeError, "Duplicate entry, header was already instantiated")
     end
   end
+
 end


### PR DESCRIPTION
Currently the obsolete parses simply one big obsolete comment with all the obsolete data in it (e.g. msgid and msgstr).

This pull requests adds functionality to the Entry class to parse the content of the obsolete comment by simply sending it without the obsolete markers to the simple_po_parser.

One caveat: The simple_po_parser is not 100% strict and will not raise an error on parsing an invalid obsolete entry (e.g. an obsolete without a msgstr), even though msgcat will. With this addition the PoParser will fail on such **invalid** po entries. I don't think this is a bad thing as the gettext utilities throw an error too.