### PR TITLE
Force the tokenizer to load files in utf-8

### DIFF
--- a/lib/poparser/tokenizer.rb
+++ b/lib/poparser/tokenizer.rb
@@ -7,7 +7,7 @@ module PoParser
 
     def extract_entries(path)
       @po.path = path
-      File.open(path, 'r').each_line("\n\n") do |block|
+      File.open(path, 'r:utf-8').each_line("\n\n") do |block|
         block.strip!
         @po << parse_block(block) if block != ''
       end


### PR DESCRIPTION
This comes about after trying to use PoParser on the Windows command line which has codepage 850 as its default encoding.

Most modern \*ix will set LC_ALL et.al. to a reasonable UTF-* encoding thus you won't notice that reading a file with File.open(bla,'r') will just try to use the terminal's encoding and thus fail miserably and spectacularly.

Given that .po files are usually meant for internationalisation it is a safe assumption that the contents   will not be limited to the old 850 codepage and that UTF-8 is a reasonable default.

This is an emergency patch to make it usable on Windows. To fix it permanently I would restructure the library to not do any file IO interactions, instead to expect the content of the .po file as a string.
You then let the user decide how to load the file. Alternately, provide a few convenience methods for specific encodings (e.g. PoParser.load_utf8(po_file) or some such)

