### PR TITLE
Fix warning in jRuby 9.1.14.0

### DIFF
--- a/lib/poparser/header.rb
+++ b/lib/poparser/header.rb
@@ -109,7 +109,7 @@ module PoParser
     def merge_to_previous_string(array)
       array.each_with_index do |key, index|
         if key.length == 1
-          array[index -1][1] += key[0]
+          array[index - 1][1] += key[0]
           array.delete_at(index)
         end
       end


### PR DESCRIPTION
This simple commit performs a cosmetic change by adding a space before a
`minus` operator in order to avoid a warning displayed in certain ruby
versions such as jRuby 9.1.14.0 and possibly all interpreters that
follow the semantics of Ruby 2.3.

We'd be very pleased if this could be merged and released as soon as possible, because it displays ugly warnings at application startup in a lot of places. The change is minimal and should not break anything. Thank you very much for having a look at this.