### PR TITLE
Fix how Entry#to_h represents Po entries with multiple lines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .yardoc
 .ruby-version
 .gitignore
+.idea/
 Gemfile.lock
 InstalledFiles
 _yardoc

--- a/lib/poparser/constants.rb
+++ b/lib/poparser/constants.rb
@@ -17,7 +17,9 @@ module PoParser
     msgid: 'msgid',
     msgid_plural: 'msgid_plural',
     msgstr: 'msgstr',
-  }.freeze
+  }
+  (0..9).to_a.each { |index| ENTRIES_LABELS["msgstr_#{index}".to_sym] = "msgstr[#{index}]" }
+  ENTRIES_LABELS.freeze
 
   LABELS = COMMENTS_LABELS.merge(ENTRIES_LABELS).keys
 

--- a/lib/poparser/entry.rb
+++ b/lib/poparser/entry.rb
@@ -84,7 +84,7 @@ module PoParser
         object = instance_variable_get(label)
         next if object.nil?
 
-        # If it's a plural msgstr
+        # If it's a multiline message/comment
         if object.value.is_a?(Array)
           hash[object.type] = object.value.compact
         else
@@ -120,9 +120,8 @@ module PoParser
       elsif ENTRIES_LABELS.include? name
         instance_variable_set "@#{name}".to_sym, Message.new(name, value)
       elsif /^msgstr\[[0-9]\]/.match?(name.to_s)
-        # If it's a plural msgstr
-        @msgstr ||= []
-        @msgstr << Message.new(name, value)
+        # If it's a plural msgstr, change instance variable name to @msgstr_n as @msgstr[n] is not a valid variable name
+        instance_variable_set "@msgstr_#{plural_form(name)}".to_sym, Message.new(name, value)
       end
     end
 
@@ -142,6 +141,10 @@ module PoParser
           klass       = instance_variable_get "@#{type}".to_sym
           klass.type  = type
           klass.value = val
+        elsif type.match(/^msgstr_\d/)
+          plural_form = type.to_s.scan(/^msgstr_(\d)/).last.first.to_i
+          object_type = "msgstr[#{plural_form}]".to_sym
+          instance_variable_set "@#{type}".to_sym, object.new(object_type, val)
         else
           instance_variable_set "@#{type}".to_sym, object.new(type, val)
         end
@@ -198,6 +201,10 @@ module PoParser
       # alias for backward compatibility of this typo
       self.class.send(:alias_method, :refrence, :reference)
       self.class.send(:alias_method, :refrence=, :reference=)
+    end
+
+    def plural_form(name)
+      name.to_s.scan(/^msgstr\[([0-9])\]/).last.first.to_i
     end
   end
 end

--- a/lib/poparser/entry.rb
+++ b/lib/poparser/entry.rb
@@ -82,13 +82,13 @@ module PoParser
     def to_h
       instance_variables.each_with_object({}) do |label, hash|
         object = instance_variable_get(label)
+        next if object.nil?
+
         # If it's a plural msgstr
-        if object.is_a?(Array)
-          object.each do |entry|
-            hash[entry.type] = entry.to_s unless entry.nil?
-          end
+        if object.value.is_a?(Array)
+          hash[object.type] = object.value.compact
         else
-          hash[object.type] = object.to_s unless object.nil?
+          hash[object.type] = object.to_s
         end
       end
     end

--- a/lib/poparser/message.rb
+++ b/lib/poparser/message.rb
@@ -20,6 +20,9 @@ module PoParser
 
       if @value.is_a? Array
         remove_empty_line
+        # special case for plural strings
+        return msgstr_plural_to_s if label == 'msgstr'
+
         # multiline messages should be started with an empty line
         lines = ["#{label} \"\"\n"]
         @value.each do |str|
@@ -45,6 +48,14 @@ module PoParser
       if @value.is_a? Array
         @value.shift if @value.first == ''
       end
+    end
+
+    def msgstr_plural_to_s
+      lines = []
+      @value.each_with_index do |str, index|
+        lines << "msgstr[#{index}] \"#{str}\"\n"
+      end
+      lines.join
     end
 
     def label

--- a/lib/poparser/message.rb
+++ b/lib/poparser/message.rb
@@ -20,9 +20,6 @@ module PoParser
 
       if @value.is_a? Array
         remove_empty_line
-        # special case for plural strings
-        return msgstr_plural_to_s if label == 'msgstr'
-
         # multiline messages should be started with an empty line
         lines = ["#{label} \"\"\n"]
         @value.each do |str|
@@ -48,14 +45,6 @@ module PoParser
       if @value.is_a? Array
         @value.shift if @value.first == ''
       end
-    end
-
-    def msgstr_plural_to_s
-      lines = []
-      @value.each_with_index do |str, index|
-        lines << "msgstr[#{index}] \"#{str}\"\n"
-      end
-      lines.join
     end
 
     def label

--- a/spec/poparser/entry_spec.rb
+++ b/spec/poparser/entry_spec.rb
@@ -23,10 +23,29 @@ describe PoParser::Entry do
     }.to raise_error(ArgumentError, "Unknown label blah_blah")
   end
 
-  it 'should show a hash presentation of a entry' do
+  it 'should show a hash presentation of an entry' do
     @entry.msgid = 'string'
     @entry.msgstr = 'reshte'
-    expect(@entry.to_h).to eq({:msgid=>"string", :msgstr=>"reshte"})
+    @entry.translator_comment = ['comment', 'second line of comments']
+    result = {
+      :translator_comment => ['comment', 'second line of comments'],
+      :msgid => 'string',
+      :msgstr => 'reshte'
+    }
+    expect(@entry.to_h).to eq(result)
+  end
+
+  it 'should show a hash presentation of a plural string entry' do
+    @entry = PoParser::Entry.new
+    @entry.msgid_plural = 'word'
+    @entry.msgstr = %w[mot mots]
+    @entry.translator_comment = ['comment', 'second line of comments']
+    result = {
+      :translator_comment => ['comment', 'second line of comments'],
+      :msgid_plural => 'word',
+      :msgstr => %w[mot mots]
+    }
+    expect(@entry.to_h).to eq(result)
   end
 
   it 'should translate the entry' do

--- a/spec/poparser/entry_spec.rb
+++ b/spec/poparser/entry_spec.rb
@@ -37,13 +37,16 @@ describe PoParser::Entry do
 
   it 'should show a hash presentation of a plural string entry' do
     @entry = PoParser::Entry.new
-    @entry.msgid_plural = 'word'
-    @entry.msgstr = %w[mot mots]
+    @entry.msgid_plural = 'right word'
+    @entry.msgstr_0 = %w[mot juste]
+    @entry.msgstr_1 = %w[mots justes]
     @entry.translator_comment = ['comment', 'second line of comments']
+
     result = {
       :translator_comment => ['comment', 'second line of comments'],
-      :msgid_plural => 'word',
-      :msgstr => %w[mot mots]
+      :msgid_plural => 'right word',
+      :'msgstr[0]' => %w[mot juste],
+      :'msgstr[1]' => %w[mots justes]
     }
     expect(@entry.to_h).to eq(result)
   end
@@ -103,7 +106,7 @@ describe PoParser::Entry do
       @entry.flag = 'fuzzy'
       @entry.msgid = ['first line', 'second line']
       @entry.msgstr = ['first line', 'second line']
-      result = "#, fuzzy\nmsgid \"\"\n\"first line\"\n\"second line\"\nmsgstr[0] \"first line\"\nmsgstr[1] \"second line\"\n"
+      result = "#, fuzzy\nmsgid \"\"\n\"first line\"\n\"second line\"\nmsgstr \"\"\n\"first line\"\n\"second line\"\n"
       expect(@entry.to_s).to eq(result)
     end
   end

--- a/spec/poparser/entry_spec.rb
+++ b/spec/poparser/entry_spec.rb
@@ -26,29 +26,30 @@ describe PoParser::Entry do
   it 'should show a hash presentation of an entry' do
     @entry.msgid = 'string'
     @entry.msgstr = 'reshte'
-    @entry.translator_comment = ['comment', 'second line of comments']
-    result = {
-      :translator_comment => ['comment', 'second line of comments'],
-      :msgid => 'string',
-      :msgstr => 'reshte'
-    }
-    expect(@entry.to_h).to eq(result)
+    expect(@entry.to_h).to eq({:msgid=>"string", :msgstr=>"reshte"})
   end
 
-  it 'should show a hash presentation of a plural string entry' do
-    @entry = PoParser::Entry.new
-    @entry.msgid_plural = 'right word'
-    @entry.msgstr_0 = %w[mot juste]
-    @entry.msgstr_1 = %w[mots justes]
-    @entry.translator_comment = ['comment', 'second line of comments']
-
-    result = {
-      :translator_comment => ['comment', 'second line of comments'],
-      :msgid_plural => 'right word',
-      :'msgstr[0]' => %w[mot juste],
-      :'msgstr[1]' => %w[mots justes]
+  it 'should show a hash representation of a complex entry' do
+    # Ensure the to_h method is reversible
+    # From SimplePoParser::Parser - https://github.com/experteer/simple_po_parser/blob/v1.1.5/spec/simple_po_parser/parser_spec.rb#L31
+    entry_hash = {
+      :translator_comment => ["translator-comment", ""],
+      :extracted_comment => "extract",
+      :reference => ["reference1", "reference2"],
+      :flag => "flag",
+      :previous_msgctxt => "previous context",
+      :previous_msgid => ["", "multiline\\n", "previous messageid"],
+      :previous_msgid_plural => "previous msgid_plural",
+      :msgctxt => "Context",
+      :msgid => "msgid",
+      :msgid_plural => ["", "multiline msgid_plural\\n", ""],
+      "msgstr[0]" => "msgstr 0",
+      "msgstr[1]" => ["", "msgstr 1 multiline 1\\n", "msgstr 1 line 2\\n"],
+      "msgstr[2]" => "msgstr 2"
     }
-    expect(@entry.to_h).to eq(result)
+
+    entry = PoParser::Entry.new(entry_hash)
+    expect(entry.to_h).to eq(entry_hash)
   end
 
   it 'should translate the entry' do

--- a/spec/poparser/entry_spec.rb
+++ b/spec/poparser/entry_spec.rb
@@ -103,7 +103,7 @@ describe PoParser::Entry do
       @entry.flag = 'fuzzy'
       @entry.msgid = ['first line', 'second line']
       @entry.msgstr = ['first line', 'second line']
-      result = "#, fuzzy\nmsgid \"\"\n\"first line\"\n\"second line\"\nmsgstr \"\"\n\"first line\"\n\"second line\"\n"
+      result = "#, fuzzy\nmsgid \"\"\n\"first line\"\n\"second line\"\nmsgstr[0] \"first line\"\nmsgstr[1] \"second line\"\n"
       expect(@entry.to_s).to eq(result)
     end
   end

--- a/spec/poparser/po_spec.rb
+++ b/spec/poparser/po_spec.rb
@@ -28,12 +28,12 @@ describe PoParser::Po do
       'msgstr[1]': 'phrases',
     }
     @po << {
-      msgid_plural: 'word',
-      msgstr: %w[word words]
+      msgid: 'multiline word',
+      msgstr: %w[line1 line2]
     }
     entry_1 = "# comment\n# another comment line\n#: reference comment\nmsgid \"untranslated\"\nmsgstr \"translated string\"\n"
     entry_2 = "msgid_plural \"phrase\"\nmsgstr[0] \"phrase\"\nmsgstr[1] \"phrases\"\n"
-    entry_3 = "msgid_plural \"word\"\nmsgstr[0] \"word\"\nmsgstr[1] \"words\"\n"
+    entry_3 = "msgid \"multiline word\"\nmsgstr \"\"\n\"line1\"\n\"line2\"\n"
 
     expect(@po.to_s).to eq(entry_1 + "\n" + entry_2 + "\n" + entry_3)
   end

--- a/spec/poparser/po_spec.rb
+++ b/spec/poparser/po_spec.rb
@@ -15,6 +15,18 @@ describe PoParser::Po do
     @po = PoParser::Po.new
   end
 
+  it 'should output the po to a sting correctly' do
+    @po << {
+      translator_comment: ['comment', 'another comment line'],
+      reference: 'reference comment',
+      msgid: 'untranslated',
+      msgstr: 'translated string'
+    }
+
+    expected = "# comment\n# another comment line\n#: reference comment\nmsgid \"untranslated\"\nmsgstr \"translated string\"\n"
+    expect(@po.to_s).to eq(expected)
+  end
+
   it 'should be able to add an entry to Po' do
     # << is an alias for Po#add
     expect(@po << entry).to be_a_kind_of PoParser::Po

--- a/spec/poparser/po_spec.rb
+++ b/spec/poparser/po_spec.rb
@@ -15,16 +15,27 @@ describe PoParser::Po do
     @po = PoParser::Po.new
   end
 
-  it 'should output the po to a sting correctly' do
+  it 'should output the po to a string correctly' do
     @po << {
       translator_comment: ['comment', 'another comment line'],
       reference: 'reference comment',
       msgid: 'untranslated',
       msgstr: 'translated string'
     }
+    @po << {
+      msgid_plural: 'phrase',
+      'msgstr[0]': 'phrase',
+      'msgstr[1]': 'phrases',
+    }
+    @po << {
+      msgid_plural: 'word',
+      msgstr: %w[word words]
+    }
+    entry_1 = "# comment\n# another comment line\n#: reference comment\nmsgid \"untranslated\"\nmsgstr \"translated string\"\n"
+    entry_2 = "msgid_plural \"phrase\"\nmsgstr[0] \"phrase\"\nmsgstr[1] \"phrases\"\n"
+    entry_3 = "msgid_plural \"word\"\nmsgstr[0] \"word\"\nmsgstr[1] \"words\"\n"
 
-    expected = "# comment\n# another comment line\n#: reference comment\nmsgid \"untranslated\"\nmsgstr \"translated string\"\n"
-    expect(@po.to_s).to eq(expected)
+    expect(@po.to_s).to eq(entry_1 + "\n" + entry_2 + "\n" + entry_3)
   end
 
   it 'should be able to add an entry to Po' do


### PR DESCRIPTION
As described in https://github.com/arashm/PoParser/issues/27 multi-line po entries did not export in such a was as they could be successfully reimported when `Entry#to_h` was called on each Entry object.

The same thing was happening to multi-line comment entries.

I've changed `Entry` so that it accepts plural form msgstr entries as `msgstr_n` instance variable and writer methods, but exports these (via `to_h`) using original `msgstr[n]` notations.


Fixes https://github.com/arashm/PoParser/issues/27