### PR TITLE
Update simple_po_parser version to 1.1.6

### DIFF
--- a/poparser.gemspec
+++ b/poparser.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   # Runtime deps
-  spec.add_runtime_dependency 'simple_po_parser', '~> 1.1.2'
+  spec.add_runtime_dependency 'simple_po_parser', '~> 1.1.6'
 
   # Development deps
   spec.add_development_dependency 'bundler', '>= 0'


### PR DESCRIPTION
Version 1.1.6 fixes a wrong assumption that multiline messages have to start with an empty string and thus incorrectly failing on files compliant with the PO standard. This should assure all new installations use 1.1.6 or newer and upgrades of PoParser also force an upgrade of simple_po_parser.

See https://github.com/arashm/PoParser/issues/24 https://github.com/experteer/simple_po_parser/issues/3 and https://github.com/experteer/simple_po_parser/pull/4

This should warrant a patch version bump to 3.2.6 and new release.